### PR TITLE
Add fish weight for Majora's Mask

### DIFF
--- a/OcarinaTextEditor/Enums/ControlTags.cs
+++ b/OcarinaTextEditor/Enums/ControlTags.cs
@@ -283,7 +283,7 @@ namespace Zelda64TextEditor.Enums
         SWAMP_CRUISE_HITS = 0x0B,
         STRAY_FAIRY_SCORE = 0x0C,
         GOLD_SKULLTULAS = 0x0D,
-        UNK_0E = 0xE,
+        FISH_WEIGHT = 0x0E,
         UNK_0F = 0xF,
         NEW_BOX = 0x10,
         LINE_BREAK = 0x11,

--- a/OcarinaTextEditor/MainWindow.xaml.cs
+++ b/OcarinaTextEditor/MainWindow.xaml.cs
@@ -163,6 +163,7 @@ namespace Zelda64TextEditor
                                                  "Hours remain",                             $"{MajoraControlCode.MOON_CRASH_HOURS_REMAIN}",        "Print time remaining in hours",
                                                  "Hours remain until morning",               $"{MajoraControlCode.UNTIL_MORNING}",                  "Print time remaining until sunrise in hours & minutes",
                                                  "Horseback Archery High Score",             $"{MajoraControlCode.EPONA_ARCHERY_HIGHSCORE}",        "Print the Epona Archery high score (Romani Ranch Balloon Game)",
+                                                 "Fish weight",                              $"{MajoraControlCode.FISH_WEIGHT}",                    "Caught fish's weight. Unused two-digit minigame score.",
                                                  "Deku Flying Highscore 1",                  $"{MajoraControlCode.DEKU_HIGHSCORE_DAY1}",            "Print the Deku Flying Highscore from Day 1)",
                                                  "Deku Flying Highscore 2",                  $"{MajoraControlCode.DEKU_HIGHSCORE_DAY2}",            "Print the Deku Flying Highscore from Day 2)",
                                                  "Deku Flying Highscore 3",                  $"{MajoraControlCode.DEKU_HIGHSCORE_DAY3}",            "Print the Deku Flying Highscore from Day 3)",


### PR DESCRIPTION
Unused two-digit minigame score.

Behaves identically to OoT fish weight:
- [z_message_PAL.c](https://github.com/zeldaret/oot/blob/616d6d4e46e7aa0c103e6b14ee8960e9a4f6dbda/src/code/z_message_PAL.c#L1379C25-L1379C25) (OoT decomp)
- [z_message_nes.c](https://github.com/HarbourMasters/mm/blob/7c7021f3a211a3384d25b5a4175040750d50c248/src/code/z_message_nes.c#L1351) (MM decomp)